### PR TITLE
.output ディレクトリを git 管理下対象外にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ dist
 
 # IDE
 .idea
+
+.output


### PR DESCRIPTION
## やりたいこと
 - SSG 生成でビルドされたものが .output に集まるので、git 管理下から外す