### PR TITLE
cloudflare pages の preset つきで SSG 生成するように

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,6 +18,10 @@ export default defineNuxtConfig({
     ],
   ],
 
+  nitro: {
+    preset: 'cloudflare_pages',
+  },
+
   vite: {
     css: {
       preprocessorOptions: {


### PR DESCRIPTION
## やりたいこと
 - nuxt generate の SSG 生成で nitro に cloudflare pages の preset がないとデプロイに失敗することがわかったため、cloudflare pages の preset を追加する。 ref: https://nitro.unjs.io/deploy/providers/cloudflare#cloudflare-pages